### PR TITLE
Remove defaults of 'null' in 'env()' calls

### DIFF
--- a/src/config/amoclient.php
+++ b/src/config/amoclient.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'client_id' => env('AMO_CLIENT_ID', null),
-    'client_secret' => env('AMO_CLIENT_SECRET', null),
+    'client_id' => env('AMO_CLIENT_ID'),
+    'client_secret' => env('AMO_CLIENT_SECRET'),
     'app_for' => env('AMO_APP_FOR', 'teachers'),
     'use_migration' => env('AMO_USE_MIGRATION', 'yes'),
     'api_log' => env('AMO_API_LOG', 'no')


### PR DESCRIPTION
`env()`'s default value [is already `null`](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Support/helpers.php#L604), so we don't need to explicitly set this here 🙂 