### PR TITLE
Use 'true' and 'false' instead of 'yes' and 'no'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Now set these keys in your .env file:
 * AMO_CLIENT_ID
 * AMO_CLIENT_SECRET
 * AMO_API_LOG
-	* Set to 'yes' to make Amoclient log all usage of access_tokens and refresh_tokens to the default log-channel.
+	* Set to `true` to make Amoclient log all usage of access_tokens and refresh_tokens to the default log-channel.
 * AMO_APP_FOR
 	* This key determines if students can login to your application. 
 	* May be one of:
@@ -21,7 +21,7 @@ Now set these keys in your .env file:
 
 Alter your User model by adding the line: `public $incrementing = false;`
 
-You should remove any default users-migration from your app, because Amoclient will conflict with it. Do _not_ remove the user-model. If you want to keep using your own migration, in your .env file set: `AMO_USE_MIGRATION=no`
+You should remove any default users-migration from your app, because Amoclient will conflict with it. Do _not_ remove the user-model. If you want to keep using your own migration, in your .env file set: `AMO_USE_MIGRATION=false`
 
 Lastly, run `php artisan migrate`.
 

--- a/src/AmoAPI.php
+++ b/src/AmoAPI.php
@@ -14,7 +14,7 @@ class AmoAPI
 	public function __construct()
 	{
 		$this->client = new \GuzzleHttp\Client;
-		$this->logging = config('amoclient.api_log') == 'yes' ? true : false;
+		$this->logging = config('amoclient.api_log');
 	}
 
 	public function get($endpoint)

--- a/src/AmoclientServiceProvider.php
+++ b/src/AmoclientServiceProvider.php
@@ -13,7 +13,7 @@ class AmoclientServiceProvider extends ServiceProvider
     {
         $this->loadRoutesFrom(__DIR__.'/routes.php');
 
-        if(config('amoclient.use_migration') == 'yes')
+        if(config('amoclient.use_migration'))
         {
             $this->loadMigrationsFrom(__DIR__.'/migrations');
         }   

--- a/src/config/amoclient.php
+++ b/src/config/amoclient.php
@@ -4,6 +4,6 @@ return [
     'client_id' => env('AMO_CLIENT_ID', null),
     'client_secret' => env('AMO_CLIENT_SECRET', null),
     'app_for' => env('AMO_APP_FOR', 'teachers'),
-    'use_migration' => env('AMO_USE_MIGRATION', 'yes'),
-    'api_log' => env('AMO_API_LOG', 'no')
+    'use_migration' => env('AMO_USE_MIGRATION', true),
+    'api_log' => env('AMO_API_LOG', false)
 ];


### PR DESCRIPTION
Instead of using the strings `'yes'` and `'no'` in `.env`, I think it'd be more logical to use PHP's native `true` and `false`. This also keeps it in line with most other "toggles" in Laravel (like `APP_DEBUG`)