### PR TITLE
Remove unused '->make()' call on the container

### DIFF
--- a/src/AmoclientServiceProvider.php
+++ b/src/AmoclientServiceProvider.php
@@ -29,7 +29,6 @@ class AmoclientServiceProvider extends ServiceProvider
             __DIR__.'/config/amoclient.php', 'amoclient'
         );
 
-        $this->app->make('StudioKaa\Amoclient\AmoclientController');
         $this->app->singleton('StudioKaa\AmoAPI', function () {
             return new AmoAPI();
         });


### PR DESCRIPTION
`->make()` on the container will resolve the given class out of the container, but here in the service provider, we're not actually using it, so we can remove that line entirely 🙂 Laravel will know how to resolve controllers out of the container automagically.