### PR TITLE
use specific jwt version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "lcobucci/jwt": "^4.0",
+        "lcobucci/jwt": "4.0.4",
         "guzzlehttp/guzzle": "^7.0"
     },
     "autoload": {


### PR DESCRIPTION
The new version of jwt does not allow an empty key in `InMemory::plainText` which we currently use in `AmoclientHelper.php`. We'll have to fix this the right way eventually, but for now this works