### PR TITLE
Add `AMO_SSL_VERIFYPEER` option + add 1M leeway for token verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ class MyController extends Controller
 		],
 	```
 	* **Note:** `../amoclient` should point to where you cloned this package
-5. Run `composer require "vendorname/packagename @dev"` inside the test project
+5. Run `composer require "studiokaa/amoclient @dev"` inside the test project
 
 You can now test and modify this package. Changes will immediately be reflected in the test project.

--- a/README.md
+++ b/README.md
@@ -10,23 +10,31 @@ __!!__ Please make sure your app is using _https_, to prevent unwanted exposure 
 To use amoclient in your project:
 
 1. In your laravel project run: `composer require studiokaa/amoclient`
+
 2. Set these keys in your .env file:
-	* AMO_CLIENT_ID
-	* AMO_CLIENT_SECRET
-	* AMO_API_LOG (optional)
-		* Default: no
-		* Set to 'yes' to make Amoclient log all usage of access_tokens and refresh_tokens to the default log-channel.
-	* AMO_APP_FOR (optional)
-		* Default: teachers
+
+	* `AMO_CLIENT_ID`
+	* `AMO_CLIENT_SECRET`
+	* `AMO_API_LOG` *(optional)*
+		* *Default:* `no`
+		* Set to `yes` to make Amoclient log all usage of access_tokens and refresh_tokens to the default log-channel.
+	* `AMO_APP_FOR` *(optional)*
+		* *Default:* `teachers`
 		* This key determines if students can login to your application. 
 		* May be one of:
-			* _all_: everyone can login, you may restrict access using guards or middleware.
-			* _teachers_: a student will be completely blocked and no user will be created when they try to login.
-	* AMO_USE_MIGRATION (optional)
-		* Default: yes
+			* `all`: everyone can login, you may restrict access using guards or middleware.
+			* `teachers`: a student will be completely blocked and no user will be created when they try to login.
+	* `AMO_USE_MIGRATION` *(optional)*
+		* *Default:* `yes`
 		* Set to no if you want to use your own migration instead of the users migration this package provides
+    * `AMO_SSL_VERIFYPEER` *(optional)*
+        * *Default:* `yes`
+        * Set to `no` if you want to disable SSL verification. This is only recommended for during development and only on trusted networks.
+
 3. Alter your User model and add the line: `public $incrementing = false;`
-4. (Recommended) Remove any default users-migration from your app, because Amoclient will conflict with it. Do _not_ remove the user-model. If you want to keep using your own migration, in your .env file set: `AMO_USE_MIGRATION=no`
+
+4. *(Recommended)* Remove any default users-migration from your app, because Amoclient will conflict with it. Do _not_ remove the user-model. If you want to keep using your own migration, in your .env file set: `AMO_USE_MIGRATION=no`
+
 5. Lastly, run `php artisan migrate`.
 
 

--- a/src/AmoAPI.php
+++ b/src/AmoAPI.php
@@ -14,7 +14,13 @@ class AmoAPI
 
 	public function __construct()
 	{
-		$this->client = new \GuzzleHttp\Client;
+        $config = [];
+
+        if (config('amoclient.ssl_verify_peer') === 'no') {
+            $config = ['curl' => [CURLOPT_SSL_VERIFYPEER => false]];
+        }
+
+		$this->client = new \GuzzleHttp\Client($config);
 		$this->logging = config('amoclient.api_log') == 'yes' ? true : false;
 	}
 
@@ -26,7 +32,7 @@ class AmoAPI
 	private function call($endpoint = 'user', $method = 'GET')
 	{
 		$access_token = session('access_token');
-		
+
 		if($access_token == null)
 		{
 			abort(401, 'No access token: probably not logged-in');

--- a/src/AmoAPI.php
+++ b/src/AmoAPI.php
@@ -89,11 +89,18 @@ class AmoAPI
 
 			return $access_token;
 		}
-		catch(\GuzzleHttp\Exception\ClientException $e)
+        catch(\GuzzleHttp\Exception\ClientException $e)
 		{
 			$this->log('refreshing token failed, redirecting for authorization');
-			$url = app('StudioKaa\Amoclient\AmoclientController')->redirect()->getTargetUrl();
-			abort(302, '', ["Location" => $url]);
+            $controller = app('StudioKaa\Amoclient\AmoclientController');
+			$redirector = $controller->redirect();
+
+            // Workaround for Livewire. TODO: Find a better way to do this.
+            if (get_class($redirector) === 'Livewire\Features\SupportRedirects\Redirector') {
+                $redirector = $redirector->response($controller->redirectUrl());
+            }
+
+            abort(302, '', ["Location" => $redirector->getTargetUrl()]);
 		}
 	}
 

--- a/src/AmoclientController.php
+++ b/src/AmoclientController.php
@@ -24,10 +24,15 @@ class AmoclientController extends Controller
 
 	public function callback(Request $request)
 	{
+        $config = [];
 
-		$http = new \GuzzleHttp\Client;
+        if (config('amoclient.ssl_verify_peer') === 'no') {
+            $config = ['curl' => [CURLOPT_SSL_VERIFYPEER => false]];
+        }
+
+		$http = new \GuzzleHttp\Client($config);
+
 		try {
-
 			//Exchange authcode for tokens
 		    $response = $http->post('https://login.curio.codes/oauth/token', [
 		        'form_params' => [

--- a/src/AmoclientController.php
+++ b/src/AmoclientController.php
@@ -11,7 +11,7 @@ use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 
 class AmoclientController extends Controller
 {
-	public function redirect()
+	public function redirectUrl()
 	{
 		$client_id = config('amoclient.client_id');
 		if($client_id == null)
@@ -19,7 +19,14 @@ class AmoclientController extends Controller
             abort(500, 'Please set AMO_CLIENT_ID and AMO_CLIENT_SECRET in .env file.');
 		}
 
-		return redirect('https://login.curio.codes/oauth/authorize?client_id=' . $client_id . '&redirect_id=' . url('amoclient/callback') . '&response_type=code');
+		return 'https://login.curio.codes/oauth/authorize?client_id=' . $client_id . '&redirect_id=' . url('amoclient/callback') . '&response_type=code';
+	}
+
+	public function redirect()
+	{
+		$url = $this->redirectUrl();
+
+		return redirect($url);
 	}
 
 	public function callback(Request $request)

--- a/src/AmoclientController.php
+++ b/src/AmoclientController.php
@@ -44,14 +44,14 @@ class AmoclientController extends Controller
             try {
                 $token = $config->parser()->parse($tokens->id_token);
             } catch (\Lcobucci\JWT\Exception $exception) {
-                abort(400, 'Access token could not be parsed!');
+                abort(400, $exception->getMessage());
             }
 
             try {
                 $constraints = $config->validationConstraints();
                 $config->validator()->assert($token, ...$constraints);
             } catch (RequiredConstraintsViolated $exception) {
-                abort(400, 'Access token could not be verified!');
+                abort(400, $exception->getMessage());
             }
 
             $claims = $token->claims();

--- a/src/AmoclientHelper.php
+++ b/src/AmoclientHelper.php
@@ -31,10 +31,17 @@ class AmoclientHelper{
         );
 
         self::$cachedConfig->setValidationConstraints(
-            new ValidAt(new SystemClock(new DateTimeZone(\date_default_timezone_get()))),
+            new ValidAt(
+                new SystemClock(
+                    new DateTimeZone(\date_default_timezone_get()),
+                ),
+                // Fixes occasional "The token was issued in the future" when we're slow (e.g: when debugging with dd)
+                // Gives us a 1 minute leeway
+                new \DateInterval('PT1M')
+            ),
             new SignedWith(new Sha256(), InMemory::plainText($client_id))
         );
-        
+
         return self::$cachedConfig;
     }
 }

--- a/src/config/amoclient.php
+++ b/src/config/amoclient.php
@@ -5,5 +5,6 @@ return [
     'client_secret' => env('AMO_CLIENT_SECRET', null),
     'app_for' => env('AMO_APP_FOR', 'teachers'),
     'use_migration' => env('AMO_USE_MIGRATION', 'yes'),
-    'api_log' => env('AMO_API_LOG', 'no')
+    'api_log' => env('AMO_API_LOG', 'no'),
+    'ssl_verify_peer' => env('AMO_SSL_VERIFYPEER', 'yes'),
 ];


### PR DESCRIPTION
* Closes #8 with a functioning workaround for Livewire (from what I tested non-livewire also still works).
* Adds a `PT1M` (Period Time 1 Minute) leeway for token verification. Sometimes token verification failed if the local server was slow for some reason (e.g: when debugging with dd) - causing a 'token issued in future' error
* Added more debug information for when token verification fails again (so we know which claims fail)
* This adds `AMO_SSL_VERIFYPEER` which is set to `yes` by default. But useful for local development, where SSL verification won't work. Setting it to `no` will disable it. Anything else verifies peer. (helps get rid of recommending ugly workarounds like [this](https://github.com/curio-team/narrowblast#curl-error-60-ssl-certificate-expired))
* Updated readme with this information

PS: I'm making this PR here, since you have the most up-to-date repo. But perhaps we should migrate to using https://github.com/curio-team/curioclient in our apps and on packagist. I'll look into this, but would appreciate if you could double check this PR and merge it if you think it's good.